### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-steampipe-minor-dependencies.yaml
+++ b/.github/workflows/check-steampipe-minor-dependencies.yaml
@@ -1,5 +1,9 @@
 name: Check Steampipe minor dependencies releases
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-steampipe/security/code-scanning/14](https://github.com/devops-ia/helm-steampipe/security/code-scanning/14)

In general, the fix is to add an explicit `permissions` block either at the workflow root (applies to all jobs) or within the specific job `check-and-update-minor-dependencies`. The block should grant the minimal rights required. This workflow needs to read the repository contents, and it ultimately creates pull requests (even though it uses a PAT for that), so a safe minimal set is `contents: read` and `pull-requests: write`. If we want to be even stricter, we could move `pull-requests: write` to the job level and keep root permissions at `contents: read`, but since there is only one job here, adding a root-level block keeps things simple.

The single best minimal change is to insert a `permissions` block near the top of `.github/workflows/check-steampipe-minor-dependencies.yaml`, right after the `name` declaration and before the `on:` block. This will apply to the sole job and ensure the default `GITHUB_TOKEN` is constrained to `contents: read` and `pull-requests: write`. No additional imports, libraries, or tooling changes are needed; we are only modifying the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
