### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-changes.yaml
+++ b/.github/workflows/check-changes.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check-and-release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-steampipe/security/code-scanning/13](https://github.com/devops-ia/helm-steampipe/security/code-scanning/13)

In general, the fix is to add an explicit `permissions:` block either at the workflow root (applies to all jobs) or inside the `check-and-release` job, granting only the scopes needed. This avoids inheriting potentially broad organization/repository defaults.

For this specific workflow, `actions/checkout` needs `contents: read`. The pull request creation is done with `secrets.PAT_GITHUB`, not `GITHUB_TOKEN`, so the job itself does not strictly require `GITHUB_TOKEN` write permissions. The safest least-privilege change—without changing existing behavior—is to define `permissions: contents: read` for the job. If, in reality, some of the third-party actions require `GITHUB_TOKEN` write access (for example, to push changes or open PRs), you would expand the block to include `contents: write` and/or `pull-requests: write`, but based solely on the provided snippet we must not assume that.

The minimal and targeted fix is therefore:
- Edit `.github/workflows/check-changes.yaml`.
- Under `jobs:`, inside `check-and-release:`, add:
  ```yaml
  permissions:
    contents: read
  ```
  between `check-and-release:` and `runs-on: ubuntu-latest`. No imports or other definitions are involved, as this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
