### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-steampipe-major-dependencies.yaml
+++ b/.github/workflows/check-steampipe-major-dependencies.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 1 * *' # first day of month
 
+permissions:
+  contents: read
+
 jobs:
   check-and-update-major-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-steampipe/security/code-scanning/12](https://github.com/devops-ia/helm-steampipe/security/code-scanning/12)

Generally, the fix is to add a `permissions` block that restricts the default `GITHUB_TOKEN` to the least privileges required. This can be added at the root of the workflow (applies to all jobs) or inside the specific job. Since there is only one job in this workflow, adding `permissions` at the workflow root is simple and clear.

The best minimal change is to add a root-level `permissions` section after the `on:` block, specifying `contents: read`. The workflow uses `secrets.GITHUB_TOKEN` mainly for read/CI tasks and uses `secrets.PAT_GITHUB` for write operations like creating pull requests, so write permissions via `GITHUB_TOKEN` are not needed. No other scopes (issues, pull-requests, etc.) are obviously required for this job, so we can keep the token read-only for repository contents. Concretely, in `.github/workflows/check-steampipe-major-dependencies.yaml`, insert:

```yaml
permissions:
  contents: read
```

aligned with `name:` and `on:` (top-level keys). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
